### PR TITLE
ci: add Delete Old Releases workflow (keep newest 3)

### DIFF
--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -1,0 +1,45 @@
+name: Delete Old Releases
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Daily at 03:00 UTC
+  workflow_dispatch:      # Manual trigger
+
+# Deleting releases needs write; declare it explicitly so this works regardless
+# of the org/repo default GITHUB_TOKEN permission (which may be read-only).
+permissions:
+  contents: write
+
+jobs:
+  clean_releases:
+    # Only run in the armbian org — never delete releases on a fork.
+    if: ${{ github.repository_owner == 'armbian' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get all releases (handle pagination)
+          releases=$(gh api --paginate repos/${{ github.repository }}/releases)
+
+          # Sort by published_at, NOT created_at: the distribution releases were
+          # bulk-migrated, so dozens share the same created_at and it does not
+          # reflect version recency (sorting by it would delete the newest
+          # releases). published_at reflects the real release order.
+
+          # Process full releases
+          full_releases=$(echo "$releases" | jq -c '[.[] | select(.prerelease == false)] | sort_by(.published_at) | reverse')
+          full_to_delete=$(echo "$full_releases" | jq '.[3:] | .[].id')
+          for id in $full_to_delete; do
+            echo "Deleting old full release ID: $id"
+            gh api --method DELETE repos/${{ github.repository }}/releases/$id
+          done
+
+          # Process pre-releases
+          pre_releases=$(echo "$releases" | jq -c '[.[] | select(.prerelease == true)] | sort_by(.published_at) | reverse')
+          pre_to_delete=$(echo "$pre_releases" | jq '.[3:] | .[].id')
+          for id in $pre_to_delete; do
+            echo "Deleting old pre-release ID: $id"
+            gh api --method DELETE repos/${{ github.repository }}/releases/$id
+          done


### PR DESCRIPTION
Ports armbian/ci's `delete-old-releases` workflow to this repo so old appliance releases are pruned automatically.

- **Schedule:** daily at 03:00 UTC + `workflow_dispatch`.
- **Retention:** keep the **3 newest** full releases and 3 newest pre-releases; delete the rest.
- Self-targets `github.repository`, uses the repo's own `GITHUB_TOKEN` with `contents: write`, and is gated to the `armbian` org.

## One deviation from the ci copy: sort by `published_at`, not `created_at`
The distribution releases were **bulk-migrated**, so dozens share an identical `created_at` (e.g. `2025-08-28`, `2024-08-29`) that does *not* reflect version recency. Sorting by `created_at` (as ci does) would have **deleted the newest releases**. `published_at` reflects the real order.

Verified keep-3 set (by `published_at`):
```
KEEP   26.8.1 (2026-08-08)
KEEP   26.5.1 (2026-06-03)
KEEP   26.2.1 (2026-02-12)
DELETE 25.11.1, 25.8.2, 25.8.1, 25.5.2, ...
```

⚠️ **Destructive on first run:** merging + first run prunes armbian/distribution down to 3 full + 3 pre-releases. If you want to retain more history for appliance images, bump the `.[3:]` slice (e.g. `.[6:]` to keep 6) before enabling.